### PR TITLE
Add card filtering to the bot selector.  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.idea

--- a/src/main/java/be/aga/dominionSimulator/DomEngine.java
+++ b/src/main/java/be/aga/dominionSimulator/DomEngine.java
@@ -409,16 +409,27 @@ public class DomEngine {
 		Collections.sort(bots);
 	}
 
-	public Object[] getBots(Object[] domBotTypes) {
+	/**
+	 * Get the list of bots that match the given criteria.
+	 * @param domBotTypes The types of bots to get.  Only bots that match all the given types will be returned.
+	 * @param cards The cards to search for.  Only bots with all the given cards in their buy rules will be returned.
+	 * @return The bots that match the given criteria.
+	 */
+	public Object[] getBots(Object[] domBotTypes, DomCardName[] cards) {
 		ArrayList<DomPlayer> theBots = new ArrayList<DomPlayer>();
-		for (DomPlayer player : bots){
-			int i;
-			for (i=0; i<domBotTypes.length;i++){
-				if (!player.hasType(domBotTypes[i]))
-					break;
+		player:
+		for (DomPlayer player : bots) {
+			for (Object type : domBotTypes) {
+				if (!player.hasType(type)) {
+					continue player;
+				}
 			}
-			if (i>=domBotTypes.length)
-				theBots.add(player);
+			for (DomCardName card : cards) {
+				if (!player.isInBuyRules(card)) {
+					continue player;
+				}
+			}
+			theBots.add(player);
 		}
 		Collections.sort(theBots);
 		return theBots.toArray();

--- a/src/main/java/be/aga/dominionSimulator/DomPlayer.java
+++ b/src/main/java/be/aga/dominionSimulator/DomPlayer.java
@@ -726,7 +726,7 @@ public class DomPlayer implements Comparable<DomPlayer> {
         buyTime += System.currentTimeMillis() - theTime;
     }
 
-    private boolean isInBuyRules(DomCardName aCard) {
+    public boolean isInBuyRules(DomCardName aCard) {
         for (DomBuyRule theBuyRule : getBuyRules()) {
             if (theBuyRule.getCardToBuy() == aCard)
                 return true;

--- a/src/main/java/be/aga/dominionSimulator/enums/DomCardName.java
+++ b/src/main/java/be/aga/dominionSimulator/enums/DomCardName.java
@@ -1564,7 +1564,7 @@ public enum DomCardName  {
 	public static Object[] getKingdomCards() {
 		ArrayList<DomCardName> theCards = new ArrayList<DomCardName>(); 
 		for (DomCardName cardName : values()){
-			if (!DomSet.Base.contains(cardName))
+			if (!DomSet.Common.contains(cardName))
 				theCards.add(cardName);
 		}
 		return theCards.toArray();

--- a/src/main/java/be/aga/dominionSimulator/gui/DomBotSelector.java
+++ b/src/main/java/be/aga/dominionSimulator/gui/DomBotSelector.java
@@ -1,13 +1,10 @@
 package be.aga.dominionSimulator.gui;
 
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
-import java.awt.event.WindowEvent;
-import java.awt.event.WindowListener;
+import be.aga.dominionSimulator.DomEngine;
+import be.aga.dominionSimulator.DomPlayer;
+import be.aga.dominionSimulator.enums.DomBotType;
+import be.aga.dominionSimulator.enums.DomCardName;
+import org.jfree.ui.RefineryUtilities;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -19,183 +16,211 @@ import javax.swing.SwingUtilities;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
-
-import org.jfree.ui.RefineryUtilities;
-
-import be.aga.dominionSimulator.DomEngine;
-import be.aga.dominionSimulator.DomPlayer;
-import be.aga.dominionSimulator.enums.DomBotType;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
 
 public class DomBotSelector extends EscapeDialog
-                            implements ListSelectionListener, ActionListener, WindowListener {
-   private DomEngine myEngine;
-   private JList myBotTypeList;
-   private JList myBotList;
+        implements ListSelectionListener, ActionListener, WindowListener, DomCardFilterPanel.CardsChangedListener {
+    private DomEngine myEngine;
+    private JList myBotTypeList;
+    private JList myBotList;
+    private DomCardFilterPanel mCardFilterPanel;
 
-   private static int[] sSelectedIndices = new int[]{8,10};
+    private static int[] sSelectedIndices = new int[]{8, 10};
 
-   Action chooseAction = new AbstractAction() {
-       public void actionPerformed(ActionEvent e) {
-   		 myEngine.setSelectedBot(myBotList.getSelectedValue());
-   		 dispose();
-       }
-   };
+    Action chooseAction = new AbstractAction() {
+        public void actionPerformed(ActionEvent e) {
+            myEngine.setSelectedBot(myBotList.getSelectedValue());
+            dispose();
+        }
+    };
 
-public DomBotSelector(DomEngine anEngine, final DomPlayer aSelectedBot) {
-	 myEngine=anEngine;
-	 buildGUI();
-   addWindowListener(this);
-	 setTitle("Select a strategy (click to select multiple types)");
-	 pack();
-	 RefineryUtilities.centerFrameOnScreen(this);
-	 setVisible(true);
-	 myBotList.requestFocus();
-     Runnable doScroll = new Runnable() {
-       public void run() {
-      	 myBotList.setSelectedValue(aSelectedBot, true);
-       }
-     };
-     SwingUtilities.invokeLater( doScroll );
-}
+    public DomBotSelector(DomEngine anEngine, final DomPlayer aSelectedBot) {
+        myEngine = anEngine;
+        buildGUI();
+        addWindowListener(this);
+        setTitle("Select a strategy (click to select multiple types)");
+        pack();
+        RefineryUtilities.centerFrameOnScreen(this);
+        setVisible(true);
+        myBotList.requestFocus();
+        Runnable doScroll = new Runnable() {
+            public void run() {
+                myBotList.setSelectedValue(aSelectedBot, true);
+            }
+        };
+        SwingUtilities.invokeLater(doScroll);
+    }
 
-private void buildGUI() {
-	setLayout( new GridBagLayout() );
-    final GridBagConstraints theCons = DomGui.getGridBagConstraints( 2 );
-	add(getSelectionPanel(), theCons);
-	theCons.gridy++;
-	add(getButtonPanel(), theCons);
-}
+    private void buildGUI() {
+        setLayout(new GridBagLayout());
+        setPreferredSize(new Dimension(600, 600));
+        final GridBagConstraints theCons = DomGui.getGridBagConstraints(2);
+        theCons.gridy++;
+        GridBagConstraints c = new GridBagConstraints();
+        c.fill = GridBagConstraints.HORIZONTAL;
+        c.gridx = 0;
+        c.gridy = 0;
+        mCardFilterPanel = new DomCardFilterPanel();
+        mCardFilterPanel.addListener(this);
+        add(mCardFilterPanel, c);
+        theCons.weighty = 1.0;
+        theCons.weightx = 1.0;
+        add(getSelectionPanel(), theCons);
+        theCons.weighty = 0.0;
+        theCons.gridy++;
+        add(getButtonPanel(), theCons);
+    }
 
-private JPanel getButtonPanel() {
-    final JPanel thePanel = new JPanel();
-    thePanel.setLayout( new GridBagLayout() );
-    final GridBagConstraints theCons = DomGui.getGridBagConstraints( 2 );
-    theCons.fill=GridBagConstraints.NONE;
-    theCons.anchor=GridBagConstraints.CENTER;
-    //Clear button
-    JButton theBTN = new JButton("Clear selection");
-    theBTN.addActionListener(this);
-    theBTN.setMnemonic('l');
-    theBTN.setActionCommand("Clear");
-    theCons.gridx++;
-    thePanel.add(theBTN,theCons);
-    theCons.gridx++;
-    DomGui.addHeavyLabel(thePanel, theCons);
-   //OK button
-    theBTN = new JButton("OK");
-    theBTN.addActionListener(this);
-    theBTN.setMnemonic('O');
-    theBTN.setActionCommand("OK");
-    theCons.gridx++;
-    thePanel.add(theBTN,theCons);
-    //Cancel button
-    theBTN = new JButton("Cancel");
-    theBTN.addActionListener(this);
-    theBTN.setMnemonic('C');
-    theBTN.setActionCommand("Cancel");
-    theCons.gridx++;
-    thePanel.add(theBTN,theCons);
-    theCons.gridx++;
-    DomGui.addHeavyLabel(thePanel, theCons);
-    //Delete button
-    theBTN = new JButton("Delete selected");
-    theBTN.addActionListener(this);
-    theBTN.setMnemonic('D');
-    theBTN.setActionCommand("Delete");
-    theCons.gridx++;
-    thePanel.add(theBTN,theCons);
-	return thePanel;
+    private JPanel getButtonPanel() {
+        final JPanel thePanel = new JPanel();
+        thePanel.setLayout(new GridBagLayout());
+        final GridBagConstraints theCons = DomGui.getGridBagConstraints(2);
+        theCons.fill = GridBagConstraints.NONE;
+        theCons.anchor = GridBagConstraints.CENTER;
+        //Clear button
+        JButton theBTN = new JButton("Clear selection");
+        theBTN.addActionListener(this);
+        theBTN.setMnemonic('l');
+        theBTN.setActionCommand("Clear");
+        theCons.gridx++;
+        thePanel.add(theBTN, theCons);
+        theCons.gridx++;
+        DomGui.addHeavyLabel(thePanel, theCons);
+        //OK button
+        theBTN = new JButton("OK");
+        theBTN.addActionListener(this);
+        theBTN.setMnemonic('O');
+        theBTN.setActionCommand("OK");
+        theCons.gridx++;
+        thePanel.add(theBTN, theCons);
+        //Cancel button
+        theBTN = new JButton("Cancel");
+        theBTN.addActionListener(this);
+        theBTN.setMnemonic('C');
+        theBTN.setActionCommand("Cancel");
+        theCons.gridx++;
+        thePanel.add(theBTN, theCons);
+        theCons.gridx++;
+        DomGui.addHeavyLabel(thePanel, theCons);
+        //Delete button
+        theBTN = new JButton("Delete selected");
+        theBTN.addActionListener(this);
+        theBTN.setMnemonic('D');
+        theBTN.setActionCommand("Delete");
+        theCons.gridx++;
+        thePanel.add(theBTN, theCons);
+        return thePanel;
+    }
 
-}
+    private JPanel getSelectionPanel() {
+        final JPanel thePanel = new JPanel();
+        thePanel.setLayout(new GridBagLayout());
+        final GridBagConstraints theCons = DomGui.getGridBagConstraints(2);
+        JScrollPane theTypePane = new JScrollPane(getBotTypeList(), JScrollPane.VERTICAL_SCROLLBAR_NEVER, JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        theTypePane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+        theTypePane.setBorder(new TitledBorder("Type"));
+        theCons.weighty = 1.0;
+        theCons.weightx = 0.0;
+        thePanel.add(theTypePane, theCons);
+        theCons.gridx++;
+        theCons.weightx = 1.0;
+        JScrollPane theBotPane = new JScrollPane(getBotList(), JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        theBotPane.setBorder(new TitledBorder("Select a strategy"));
+        thePanel.add(theBotPane, theCons);
+        return thePanel;
+    }
 
-private JPanel getSelectionPanel() {
-    final JPanel thePanel = new JPanel();
-    thePanel.setLayout( new GridBagLayout() );
-    final GridBagConstraints theCons = DomGui.getGridBagConstraints( 2 );
-    JScrollPane theTypePane = new JScrollPane(getBotTypeList(), JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-    theTypePane.setBorder(new TitledBorder( "Type" ));
-    theTypePane.setPreferredSize(new Dimension(150,400));
-    thePanel.add(theTypePane,theCons);
-    theCons.gridx++;
-    JScrollPane theBotPane = new JScrollPane(getBotList(), JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-    theBotPane.setBorder(new TitledBorder( "Select a strategy" ));
-    theBotPane.setPreferredSize(new Dimension(350,400));
-    thePanel.add(theBotPane,theCons);
-    return thePanel;
-}
+    private JList getBotTypeList() {
+        myBotTypeList = new JList(DomBotType.values());
+        myBotTypeList.setSelectionModel(new ToggleListSelectionModel());
+        myBotTypeList.setSelectedIndices(sSelectedIndices);
+        myBotTypeList.addListSelectionListener(this);
+        SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                // Fix an annoying issue where space is left for the vertical scroll bar after initial layout even
+                // when it isn't needed.
+                myBotTypeList.revalidate();
+                myBotTypeList.repaint();
+            }
+        });
+        return myBotTypeList;
+    }
 
-private JList getBotTypeList() {
-	myBotTypeList = new JList(DomBotType.values());
-  myBotTypeList.setSelectionModel(new ToggleListSelectionModel());
-	myBotTypeList.setSelectedIndices(sSelectedIndices);
-	myBotTypeList.addListSelectionListener(this);
-	return myBotTypeList;
-}
+    @SuppressWarnings("serial")
+    private JList getBotList() {
+        myBotList = new JList(myEngine.getBots(myBotTypeList.getSelectedValues(), new DomCardName[]{})) {
+            // This method is called as the cursor moves within the list.
+            public String getToolTipText(MouseEvent evt) {
+                int index = locationToIndex(evt.getPoint());
+                Object item = getModel().getElementAt(index);
+                String theDescription = ((DomPlayer) item).getDescription().replaceAll("XXXX", "<br>");
+                return "<html>" + theDescription + "</html>";
+            }
+        };
+        new ListAction(myBotList, chooseAction);
+        return myBotList;
+    }
 
-@SuppressWarnings("serial")
-private JList getBotList() {
-	myBotList = new JList(myEngine.getBots(myBotTypeList.getSelectedValues())) {
-    // This method is called as the cursor moves within the list.
-	    public String getToolTipText(MouseEvent evt) {
-	        int index = locationToIndex(evt.getPoint());
-	        Object item = getModel().getElementAt(index);
-	        String theDescription = ((DomPlayer)item).getDescription().replaceAll("XXXX", "<br>");
-	        return "<html>"+theDescription+"</html>";
-	    }
-	};
-	new ListAction(myBotList, chooseAction);
-	return myBotList;
-}
+    public void valueChanged(ListSelectionEvent e) {
+        if (e.getSource().equals(myBotTypeList)) {
+            updateBotList();
+        }
+    }
 
-@Override
-public void valueChanged(ListSelectionEvent e) {
-	if ( e.getSource().equals(myBotTypeList)){
-	  myBotList.setListData(myEngine.getBots(myBotTypeList.getSelectedValues()));
-	  myBotList.requestFocus();
-	}
-}
+    public void cardsChanged(DomCardName[] cards) {
+        updateBotList();
+    }
 
-@Override
-public void actionPerformed(ActionEvent e) {
-	if (e.getActionCommand().equals("Cancel")){
-		dispose();
-	}
-	if (e.getActionCommand().equals("OK")){
-		myEngine.setSelectedBot(myBotList.getSelectedValue());
-		dispose();
-	}
-	if (e.getActionCommand().equals("Clear")){
-		myEngine.setSelectedBot(null);
-		dispose();
-	}
-	if (e.getActionCommand().equals("Delete")){
-		myEngine.deleteBot((DomPlayer) myBotList.getSelectedValue());
-		myBotList.setListData(myEngine.getBots(myBotTypeList.getSelectedValues()));
-		myBotList.requestFocus();
-	}
-}
+    private void updateBotList() {
+        myBotList.setListData(myEngine.getBots(myBotTypeList.getSelectedValues(), mCardFilterPanel.getSelectedCards()));
+        myBotList.requestFocus();
+    }
 
-  public void windowClosed(WindowEvent arg0) {
-    // Store the current type filter for the next time.
-    sSelectedIndices = myBotTypeList.getSelectedIndices();
-  }
+    public void actionPerformed(ActionEvent e) {
+        if (e.getActionCommand().equals("Cancel")) {
+            dispose();
+        }
+        if (e.getActionCommand().equals("OK")) {
+            myEngine.setSelectedBot(myBotList.getSelectedValue());
+            dispose();
+        }
+        if (e.getActionCommand().equals("Clear")) {
+            myEngine.setSelectedBot(null);
+            dispose();
+        }
+        if (e.getActionCommand().equals("Delete")) {
+            myEngine.deleteBot((DomPlayer) myBotList.getSelectedValue());
+            updateBotList();
+        }
+    }
 
-  public void windowActivated(WindowEvent arg0) {
-  }
+    public void windowClosed(WindowEvent arg0) {
+        // Store the current type filter for the next time.
+        sSelectedIndices = myBotTypeList.getSelectedIndices();
+    }
 
-  public void windowClosing(WindowEvent arg0) {
-  }
+    public void windowActivated(WindowEvent arg0) {
+    }
 
-  public void windowDeactivated(WindowEvent arg0) {
-  }
+    public void windowClosing(WindowEvent arg0) {
+    }
 
-  public void windowDeiconified(WindowEvent arg0) {
-  }
+    public void windowDeactivated(WindowEvent arg0) {
+    }
 
-  public void windowIconified(WindowEvent arg0) {
-  }
+    public void windowDeiconified(WindowEvent arg0) {
+    }
 
-  public void windowOpened(WindowEvent arg0) {
-  }
+    public void windowIconified(WindowEvent arg0) {
+    }
 
+    public void windowOpened(WindowEvent arg0) {
+    }
 }

--- a/src/main/java/be/aga/dominionSimulator/gui/DomCardFilterPanel.java
+++ b/src/main/java/be/aga/dominionSimulator/gui/DomCardFilterPanel.java
@@ -1,0 +1,102 @@
+package be.aga.dominionSimulator.gui;
+
+import be.aga.dominionSimulator.enums.DomCardName;
+
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JPanel;
+import javax.swing.border.EmptyBorder;
+import javax.swing.border.TitledBorder;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
+import java.awt.FlowLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.HashSet;
+
+/**
+ * A Panel that manages a selection of Kingdom cards.
+ */
+public class DomCardFilterPanel extends JPanel {
+
+    private HashSet<DomCardName> mSelectedCards = new HashSet<DomCardName>();
+    private JPanel mCardsPane = new JPanel(new WrapLayout(FlowLayout.LEFT));
+    private CardsChangedListener mListener = null;
+
+    public DomCardFilterPanel() {
+        super(new GridBagLayout());
+
+        setBorder(new TitledBorder("Card Filter"));
+        final JComboBox cardsCB = new JComboBox(DomCardName.getKingdomCards());
+        cardsCB.setBorder(new EmptyBorder(6, 0, 7, 0));
+        cardsCB.setSelectedIndex(-1);
+
+        GridBagConstraints c = new GridBagConstraints();
+        c.anchor = GridBagConstraints.FIRST_LINE_START;
+        c.gridx = 0;
+        c.gridy = 0;
+        add(cardsCB, c);
+
+        c.gridx++;
+        c.weightx = 1.0;
+        c.fill = GridBagConstraints.HORIZONTAL;
+        add(mCardsPane, c);
+
+        cardsCB.addPopupMenuListener(new PopupMenuListener() {
+            public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+            }
+
+            public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+                DomCardName cardName = (DomCardName) cardsCB.getSelectedItem();
+                if (cardName != null) {
+                    addCard(cardName);
+                }
+            }
+
+            public void popupMenuCanceled(PopupMenuEvent e) {
+            }
+        });
+    }
+
+    public DomCardName[] getSelectedCards() {
+        return mSelectedCards.toArray(new DomCardName[mSelectedCards.size()]);
+    }
+
+    public void addListener(CardsChangedListener l) {
+        mListener = l;
+    }
+
+    private void cardsChanged() {
+        revalidate();
+        repaint();
+        if (mListener != null) {
+            mListener.cardsChanged(getSelectedCards());
+        }
+    }
+
+    private void addCard(final DomCardName card) {
+        if (mSelectedCards.contains(card)) {
+            return;
+        }
+        mSelectedCards.add(card);
+        final JButton cardButton = new JButton(card.toString());
+        cardButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                mSelectedCards.remove(card);
+                mCardsPane.remove(cardButton);
+                cardsChanged();
+            }
+        });
+        cardButton.setMargin(new Insets(-15, -15, -15, -15));
+        mCardsPane.add(cardButton);
+        cardsChanged();
+    }
+
+    public interface CardsChangedListener {
+        void cardsChanged(DomCardName[] cards);
+    }
+
+}

--- a/src/main/java/be/aga/dominionSimulator/gui/WrapLayout.java
+++ b/src/main/java/be/aga/dominionSimulator/gui/WrapLayout.java
@@ -1,0 +1,180 @@
+package be.aga.dominionSimulator.gui;
+
+import java.awt.*;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+
+/**
+ * FlowLayout subclass that fully supports wrapping of components.
+ */
+public class WrapLayout extends FlowLayout {
+    private Dimension preferredLayoutSize;
+
+    /**
+     * Constructs a new <code>WrapLayout</code> with a left
+     * alignment and a default 5-unit horizontal and vertical gap.
+     */
+    public WrapLayout() {
+        super();
+    }
+
+    /**
+     * Constructs a new <code>FlowLayout</code> with the specified
+     * alignment and a default 5-unit horizontal and vertical gap.
+     * The value of the alignment argument must be one of
+     * <code>WrapLayout</code>, <code>WrapLayout</code>,
+     * or <code>WrapLayout</code>.
+     *
+     * @param align the alignment value
+     */
+    public WrapLayout(int align) {
+        super(align);
+    }
+
+    /**
+     * Creates a new flow layout manager with the indicated alignment
+     * and the indicated horizontal and vertical gaps.
+     * <p>
+     * The value of the alignment argument must be one of
+     * <code>WrapLayout</code>, <code>WrapLayout</code>,
+     * or <code>WrapLayout</code>.
+     *
+     * @param align the alignment value
+     * @param hgap  the horizontal gap between components
+     * @param vgap  the vertical gap between components
+     */
+    public WrapLayout(int align, int hgap, int vgap) {
+        super(align, hgap, vgap);
+    }
+
+    /**
+     * Returns the preferred dimensions for this layout given the
+     * <i>visible</i> components in the specified target container.
+     *
+     * @param target the component which needs to be laid out
+     * @return the preferred dimensions to lay out the
+     * subcomponents of the specified container
+     */
+    @Override
+    public Dimension preferredLayoutSize(Container target) {
+        return layoutSize(target, true);
+    }
+
+    /**
+     * Returns the minimum dimensions needed to layout the <i>visible</i>
+     * components contained in the specified target container.
+     *
+     * @param target the component which needs to be laid out
+     * @return the minimum dimensions to lay out the
+     * subcomponents of the specified container
+     */
+    @Override
+    public Dimension minimumLayoutSize(Container target) {
+        Dimension minimum = layoutSize(target, false);
+        minimum.width -= (getHgap() + 1);
+        return minimum;
+    }
+
+    /**
+     * Returns the minimum or preferred dimension needed to layout the target
+     * container.
+     *
+     * @param target    target to get layout size for
+     * @param preferred should preferred size be calculated
+     * @return the dimension to layout the target container
+     */
+    private Dimension layoutSize(Container target, boolean preferred) {
+        synchronized (target.getTreeLock()) {
+            //  Each row must fit with the width allocated to the containter.
+            //  When the container width = 0, the preferred width of the container
+            //  has not yet been calculated so lets ask for the maximum.
+
+            int targetWidth = target.getSize().width;
+            Container container = target;
+
+            while (container.getSize().width == 0 && container.getParent() != null) {
+                container = container.getParent();
+            }
+
+            targetWidth = container.getSize().width;
+
+            if (targetWidth == 0)
+                targetWidth = Integer.MAX_VALUE;
+
+            int hgap = getHgap();
+            int vgap = getVgap();
+            Insets insets = target.getInsets();
+            int horizontalInsetsAndGap = insets.left + insets.right + (hgap * 2);
+            int maxWidth = targetWidth - horizontalInsetsAndGap;
+
+            //  Fit components into the allowed width
+
+            Dimension dim = new Dimension(0, 0);
+            int rowWidth = 0;
+            int rowHeight = 0;
+
+            int nmembers = target.getComponentCount();
+
+            for (int i = 0; i < nmembers; i++) {
+                Component m = target.getComponent(i);
+
+                if (m.isVisible()) {
+                    Dimension d = preferred ? m.getPreferredSize() : m.getMinimumSize();
+
+                    //  Can't add the component to current row. Start a new row.
+
+                    if (rowWidth + d.width > maxWidth) {
+                        addRow(dim, rowWidth, rowHeight);
+                        rowWidth = 0;
+                        rowHeight = 0;
+                    }
+
+                    //  Add a horizontal gap for all components after the first
+
+                    if (rowWidth != 0) {
+                        rowWidth += hgap;
+                    }
+
+                    rowWidth += d.width;
+                    rowHeight = Math.max(rowHeight, d.height);
+                }
+            }
+
+            addRow(dim, rowWidth, rowHeight);
+
+            dim.width += horizontalInsetsAndGap;
+            dim.height += insets.top + insets.bottom + vgap * 2;
+
+            //	When using a scroll pane or the DecoratedLookAndFeel we need to
+            //  make sure the preferred size is less than the size of the
+            //  target containter so shrinking the container size works
+            //  correctly. Removing the horizontal gap is an easy way to do this.
+
+            Container scrollPane = SwingUtilities.getAncestorOfClass(JScrollPane.class, target);
+
+            if (scrollPane != null && target.isValid()) {
+                dim.width -= (hgap + 1);
+            }
+
+            return dim;
+        }
+    }
+
+    /*
+     *  A new row has been completed. Use the dimensions of this row
+     *  to update the preferred size for the container.
+     *
+     *  @param dim update the width and height when appropriate
+     *  @param rowWidth the width of the row to add
+     *  @param rowHeight the height of the row to add
+     */
+    private void addRow(Dimension dim, int rowWidth, int rowHeight) {
+        dim.width = Math.max(dim.width, rowWidth);
+
+        if (dim.height > 0) {
+            dim.height += getVgap();
+        }
+
+        dim.height += rowHeight;
+    }
+}


### PR DESCRIPTION
Users can now select a set of kingdom cards, and the bot list will only show bots that use all of the selected cards.  For example, you can quickly find all the the strategies that use the card 'Goons'.