### PR TITLE
Add a search field to the bot selector.

### DIFF
--- a/src/main/java/be/aga/dominionSimulator/DomEngine.java
+++ b/src/main/java/be/aga/dominionSimulator/DomEngine.java
@@ -450,16 +450,27 @@ public class DomEngine {
 		Collections.sort(bots);
 	}
 
-	public Object[] getBots(Object[] domBotTypes) {
+	public Object[] getBots(Object[] domBotTypes, String[] keywords) {
 		ArrayList<DomPlayer> theBots = new ArrayList<DomPlayer>();
-		for (DomPlayer player : bots){
-			int i;
-			for (i=0; i<domBotTypes.length;i++){
-				if (!player.hasType(domBotTypes[i]))
-					break;
+		player:
+		for (DomPlayer player : bots) {
+			for (Object type : domBotTypes) {
+				if (!player.hasType(type)) {
+					continue player;
+			    }
+		    }
+		    if (keywords != null) {
+				keyword:
+				for (String searchKeyword : keywords) {
+					for (String playerKeyword : player.getKeywords()) {
+						if (playerKeyword.startsWith(searchKeyword)) {
+							continue keyword;
+						}
+					}
+					continue player;
+				}
 			}
-			if (i>=domBotTypes.length)
-				theBots.add(player);
+			theBots.add(player);
 		}
 		Collections.sort(theBots);
 		return theBots.toArray();

--- a/src/main/java/be/aga/dominionSimulator/DomPlayer.java
+++ b/src/main/java/be/aga/dominionSimulator/DomPlayer.java
@@ -29,6 +29,7 @@ public class DomPlayer implements Comparable<DomPlayer> {
     private ArrayList<DomBuyRule> buyRules = new ArrayList<DomBuyRule>();
     private ArrayList<DomBuyRule> prizeBuyRules = new ArrayList<DomBuyRule>();
     private EnumMap<DomCardName, DomPlayStrategy> playStrategies = new EnumMap<DomCardName, DomPlayStrategy>(DomCardName.class);
+    private String[] keywords = null;
 
     private DomDeck deck = new DomDeck(this);
     private ArrayList<DomCard> cardsInPlay = new ArrayList<DomCard>();
@@ -2103,6 +2104,7 @@ public class DomPlayer implements Comparable<DomPlayer> {
         } else {
             buyRules.add(buyRule);
         }
+        clearKeywords();
     }
 
     public DomPlayer getCopy(String aName) {
@@ -2377,6 +2379,7 @@ public class DomPlayer implements Comparable<DomPlayer> {
             theNewRule.addCondition(theCondition);
             getBuyRules().add(getBuyRules().indexOf(theRule), theNewRule);
         }
+        clearKeywords();
         return;
     }
 
@@ -3290,5 +3293,25 @@ public class DomPlayer implements Comparable<DomPlayer> {
 
     public double getDrawDeckSize() {
         return getDeck().getDrawDeckSize();
+    }
+
+    private void clearKeywords() {
+        keywords = null;
+    }
+
+    public String[] getKeywords() {
+        if (keywords == null) {
+            HashSet<String> kws = new HashSet<String>();
+            for (DomBuyRule rule : buyRules) {
+                for (String word : rule.getCardToBuy().toString().trim().split("[\\W/]+")) {
+                    kws.add(word.toLowerCase(Locale.ENGLISH));
+                }
+            }
+            for (String word : name.trim().split("[\\W/]+")) {
+                kws.add(word.toLowerCase(Locale.ENGLISH));
+            }
+            keywords = kws.toArray(new String[kws.size()]);
+        }
+        return keywords;
     }
 }


### PR DESCRIPTION
Users can now search for bots by keywords, which include any word tokens in the bot title, or in any of the cards in the buy rules.

The search logic is pretty naive but seems fast enough.  There are lots of options for improving performance in the future if necessary.