### PR TITLE
Making getGainsNeededToEndGame not count events as cards that can be …

### DIFF
--- a/src/main/java/be/aga/dominionSimulator/DomBoard.java
+++ b/src/main/java/be/aga/dominionSimulator/DomBoard.java
@@ -845,7 +845,9 @@ public class DomBoard extends EnumMap< DomCardName, ArrayList<DomCard> > {
 			return gainsNeededToEndGame;
 		ArrayList<Integer> theCounts = new ArrayList<Integer>();
 		for (DomCardName cardName : keySet()){
-			theCounts.add(get(cardName).size());
+			if (!cardName.hasCardType(DomCardType.Event)) {
+				theCounts.add(get(cardName).size());
+			}
 		}
 		Collections.sort(theCounts);
 		int theCountGainsToEndGame = theCounts.get(0) + theCounts.get(1) + theCounts.get(2);


### PR DESCRIPTION
Currently the DomBoard getGainsNeededToEndGame method understates the number of gains required to end the game as it counts events as empty piles.
This change makes it ignore events when counting gains needed.