### PR TITLE
Making two of the token buy conditions consider the card they are on

### DIFF
--- a/src/main/java/be/aga/dominionSimulator/DomBuyCondition.java
+++ b/src/main/java/be/aga/dominionSimulator/DomBuyCondition.java
@@ -133,7 +133,7 @@ public class DomBuyCondition {
               leftValue = leftCardName.equals(owner.getMinus$2TokenOn()) ? 1 : 0;
               break;
           case isEstateTokenPlaced:
-              leftValue = leftCardName.equals(owner.getEstateTokenOn().getName()) ? 1 : 0;
+              leftValue = owner.getEstateTokenOn() != null && leftCardName.equals(owner.getEstateTokenOn().getName()) ? 1 : 0;
               break;
           case isTrashingTokenPlaced:
               leftValue=owner.isTrashingTokenSet()?1:0;
@@ -238,7 +238,7 @@ public class DomBuyCondition {
               rightValue = rightCardName.equals(owner.getMinus$2TokenOn()) ? 1 : 0;
               break;
           case isEstateTokenPlaced:
-              rightValue = rightCardName.equals(owner.getEstateTokenOn().getName()) ? 1 : 0;
+              rightValue = owner.getEstateTokenOn() != null && rightCardName.equals(owner.getEstateTokenOn().getName()) ? 1 : 0;
               break;
           case isTrashingTokenPlaced:
               rightValue=owner.isTrashingTokenSet()?1:0;

--- a/src/main/java/be/aga/dominionSimulator/DomBuyCondition.java
+++ b/src/main/java/be/aga/dominionSimulator/DomBuyCondition.java
@@ -133,7 +133,7 @@ public class DomBuyCondition {
               leftValue = leftCardName.equals(owner.getMinus$2TokenOn()) ? 1 : 0;
               break;
           case isEstateTokenPlaced:
-              leftValue = leftCardName.equals(owner.getEstateTokenOn()) ? 1 : 0;
+              leftValue = leftCardName.equals(owner.getEstateTokenOn().getName()) ? 1 : 0;
               break;
           case isTrashingTokenPlaced:
               leftValue=owner.isTrashingTokenSet()?1:0;
@@ -238,7 +238,7 @@ public class DomBuyCondition {
               rightValue = rightCardName.equals(owner.getMinus$2TokenOn()) ? 1 : 0;
               break;
           case isEstateTokenPlaced:
-              rightValue = rightCardName.equals(owner.getEstateTokenOn()) ? 1 : 0;
+              rightValue = rightCardName.equals(owner.getEstateTokenOn().getName()) ? 1 : 0;
               break;
           case isTrashingTokenPlaced:
               rightValue=owner.isTrashingTokenSet()?1:0;

--- a/src/main/java/be/aga/dominionSimulator/DomBuyCondition.java
+++ b/src/main/java/be/aga/dominionSimulator/DomBuyCondition.java
@@ -130,10 +130,10 @@ public class DomBuyCondition {
               leftValue=owner.isPlusOneCoinTokenSet() ? 1:0;
               break;
           case isMinus$2TokenSet:
-              leftValue=owner.getMinus$2TokenOn()==null?0:1;
+              leftValue = leftCardName.equals(owner.getMinus$2TokenOn()) ? 1 : 0;
               break;
           case isEstateTokenPlaced:
-              leftValue=owner.getEstateTokenOn()==null?0:1;
+              leftValue = leftCardName.equals(owner.getEstateTokenOn()) ? 1 : 0;
               break;
           case isTrashingTokenPlaced:
               leftValue=owner.isTrashingTokenSet()?1:0;
@@ -235,10 +235,10 @@ public class DomBuyCondition {
               rightValue=owner.isPlusOneCoinTokenSet() ? 1:0;
               break;
           case isMinus$2TokenSet:
-              rightValue=owner.getMinus$2TokenOn()==null?0:1;
+              rightValue = rightCardName.equals(owner.getMinus$2TokenOn()) ? 1 : 0;
               break;
           case isEstateTokenPlaced:
-              rightValue=owner.getEstateTokenOn()==null?0:1;
+              rightValue = rightCardName.equals(owner.getEstateTokenOn()) ? 1 : 0;
               break;
           case isTrashingTokenPlaced:
               rightValue=owner.isTrashingTokenSet()?1:0;


### PR DESCRIPTION
Previously the isMinus$2TokenSet and isEstateTokenPlaced buy conditions ignored whether or not the tokens were on the cards specified in the dropdown menu.

May also want to do this for isPlusOneBuyTokenSet, isPlusOneCardTokenSet, isPlusOneActionTokenSet, isPlusOneCoinTokenSet and isTrashingTokenPlaced.