### PR TITLE
Additional statistics gathering

### DIFF
--- a/src/main/java/be/aga/dominionSimulator/DomBoard.java
+++ b/src/main/java/be/aga/dominionSimulator/DomBoard.java
@@ -1226,4 +1226,8 @@ public class DomBoard extends EnumMap< DomCardName, ArrayList<DomCard> > {
     public ArrayList<DomCard> getDruidBoons() {
         return druidBoons;
     }
+
+    public ArrayList<DomPlayer> getPlayers() {
+        return players;
+    }
 }

--- a/src/main/java/be/aga/dominionSimulator/DomEngine.java
+++ b/src/main/java/be/aga/dominionSimulator/DomEngine.java
@@ -16,6 +16,7 @@ import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.filechooser.FileFilter;
 
+import be.aga.dominionSimulator.stats.StatsManager;
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -204,6 +205,7 @@ public class DomEngine {
       myGui.setBarChart(new DomBarChart(players));
       myGui.setVPLineChart(new DomLineChart(players, "VP"));
       myGui.setMoneyLineChart(new DomLineChart(players, "Money"));
+      myGui.updateStatisticsBreakdown();
       myGui.validate();
 	}
 
@@ -314,6 +316,7 @@ public class DomEngine {
         findWinnerTime=0;
         boardResetTime=0;
         totalVPTokens=0;
+		StatsManager.resetCurrentSeries();
         for (int i=0;i<NUMBER_OF_GAMES;i++) {
             if (!keepOrder) {
               Collections.shuffle(players);

--- a/src/main/java/be/aga/dominionSimulator/DomGame.java
+++ b/src/main/java/be/aga/dominionSimulator/DomGame.java
@@ -6,6 +6,7 @@ import java.util.Observable;
 
 import be.aga.dominionSimulator.cards.*;
 import be.aga.dominionSimulator.enums.DomArtifact;
+import be.aga.dominionSimulator.stats.StatsManager;
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Logger;
 import org.apache.log4j.SimpleLayout;
@@ -135,6 +136,7 @@ public void runSimulation() {
           previousTurnTakenBy = activePlayer;
         }
     } while (!isGameFinished()||fleetTurnsLeft() );
+    StatsManager.addStatsToCurrentSeries(board);
     DomEngine.logPlayerIndentation = 0;
 }
 

--- a/src/main/java/be/aga/dominionSimulator/gui/DomStatsBreakdown.java
+++ b/src/main/java/be/aga/dominionSimulator/gui/DomStatsBreakdown.java
@@ -1,0 +1,137 @@
+package be.aga.dominionSimulator.gui;
+
+import be.aga.dominionSimulator.enums.DomCardName;
+import be.aga.dominionSimulator.enums.DomCardType;
+import be.aga.dominionSimulator.stats.SeriesStats;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTable;
+import javax.swing.RowSorter;
+import javax.swing.SortOrder;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableModel;
+import javax.swing.table.TableRowSorter;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.GridLayout;
+import java.text.DecimalFormat;
+import java.util.Arrays;
+import java.util.Map;
+
+public class DomStatsBreakdown {
+
+    private static final DecimalFormat FORMATTER = new DecimalFormat("#.0");
+
+    private final JPanel statsPanel = new JPanel();
+
+    public DomStatsBreakdown() {
+        update(SeriesStats.EMPTY_SERIES_STATS);
+    }
+
+    public Component getStatsPanel() {
+        return statsPanel;
+    }
+
+    public void update(SeriesStats seriesStats) {
+        JPanel topPanel = new JPanel();
+        topPanel.setLayout(new GridLayout());
+        topPanel.add(generateCardsTable(generatePilesTableModel(seriesStats), "Average cards in piles"));
+        topPanel.add(generateCardsTable(generateTrashPileTableModel(seriesStats), "Average cards in the trash"));
+        JSplitPane split = new JSplitPane(JSplitPane.VERTICAL_SPLIT, topPanel, generatePlayersPanel(seriesStats));
+        split.setResizeWeight(0.5);
+
+        statsPanel.removeAll();
+        statsPanel.setLayout(new BorderLayout());
+        statsPanel.add(split, BorderLayout.CENTER);
+    }
+
+    private Component generatePlayersPanel(SeriesStats seriesStats) {
+        JPanel parent = new JPanel();
+        parent.setLayout(new GridLayout());
+        seriesStats.getAverageStatsForPlayers().forEach(player -> parent.add(generatePlayerPanel(player)));
+        return parent;
+    }
+
+    private Component generatePlayerPanel(SeriesStats.AverageStatsForPlayer averageStatsForPlayer) {
+        String playerText = averageStatsForPlayer.getName() + ": " + FORMATTER.format(averageStatsForPlayer.getAverageVictoryPoints()) + " VP average";
+        return generateCardsTable(generatePlayerTableModel(averageStatsForPlayer), playerText);
+    }
+
+    private TableModel generatePlayerTableModel(SeriesStats.AverageStatsForPlayer averageStatsForPlayer) {
+        return generateTableModel(averageStatsForPlayer.getAverageCardsInTheDeck(), "Card", "In the deck");
+    }
+
+    private TableModel generatePilesTableModel(SeriesStats seriesStats) {
+        return generateTableModel(seriesStats.getAveragePiles(), "Pile", "Cards left");
+    }
+
+    private TableModel generateTrashPileTableModel(SeriesStats seriesStats) {
+        return generateTableModel(seriesStats.getAverageTrashPile(), "Card", "In trash");
+    }
+
+    private TableModel generateTableModel(Map<DomCardName, Double> data, String firstColumnName, String secondColumnName) {
+        DefaultTableModel model = new DefaultTableModel() {
+            @Override
+            public Class<?> getColumnClass(int column) {
+                return column == 0 ? DomCardName.class : Double.class;
+            }
+        };
+        model.addColumn(firstColumnName);
+        model.addColumn(secondColumnName);
+        data.forEach((name, averageCards) -> model.addRow(new Object[] {name, averageCards}));
+        return model;
+    }
+
+    private Component generateCardsTable(TableModel model, String caption) {
+        JPanel parent = new JPanel();
+        parent.setLayout(new BorderLayout(5, 5));
+        parent.add(new JLabel(caption), BorderLayout.NORTH);
+        JTable table = new JTable(model) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return false;
+            }
+        };
+        table.setDefaultRenderer(DomCardName.class, new DominionCardTableRowRenderer());
+        table.setDefaultRenderer(Double.class, new DominionCardTableRowRenderer());
+        table.getTableHeader().setReorderingAllowed(false);
+
+        TableRowSorter<TableModel> sorter = new TableRowSorter<>(model);
+        sorter.setSortKeys(Arrays.asList(
+            new RowSorter.SortKey(1, SortOrder.DESCENDING),
+            new RowSorter.SortKey(0, SortOrder.ASCENDING)
+            ));
+        table.setRowSorter(sorter);
+
+        parent.add(new JScrollPane(table), BorderLayout.CENTER);
+        return parent;
+    }
+
+    private static class DominionCardTableRowRenderer extends DefaultTableCellRenderer {
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+            Component component = super
+                .getTableCellRendererComponent(table, value instanceof Double ? FORMATTER.format(value) : value, isSelected, hasFocus, row, column);
+            component.setBackground(calculateRowColor((DomCardName) table.getValueAt(row, 0)));
+            return component;
+        }
+
+        private Color calculateRowColor(DomCardName card) {
+            if (card.hasCardType(DomCardType.Victory)) {
+                return new Color(0xC1E4A5);
+            } else if (card.hasCardType(DomCardType.Treasure)) {
+                return new Color(0xFFDE2E);
+            } else if (card.hasCardType(DomCardType.Night)) {
+                return new Color(0x777777);
+            } else if (card.hasCardType(DomCardType.Curse)) {
+                return new Color(0xCCC4FC);
+            } else {
+                return Color.white;
+            }
+        }
+    }
+}

--- a/src/main/java/be/aga/dominionSimulator/stats/AverageStatsCalculator.java
+++ b/src/main/java/be/aga/dominionSimulator/stats/AverageStatsCalculator.java
@@ -1,0 +1,81 @@
+package be.aga.dominionSimulator.stats;
+
+import be.aga.dominionSimulator.enums.DomCardName;
+import be.aga.dominionSimulator.enums.DomCardType;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static be.aga.dominionSimulator.stats.SingleGameStats.DUMMY_STATS;
+import static be.aga.dominionSimulator.stats.SingleGameStats.Player.DUMMY;
+
+public class AverageStatsCalculator {
+
+    public SeriesStats calculateStats(Collection<SingleGameStats> gameByGameStats) {
+        Map<DomCardName, Double> averagePiles = calculateAveragePiles(gameByGameStats);
+        Set<DomCardName> cardsPresentInEveryGame = averagePiles.keySet();
+
+        return new SeriesStats(
+            calculateAverageStatsForPlayers(gameByGameStats, cardsPresentInEveryGame),
+            averagePiles,
+            calculateAverageTrashPile(gameByGameStats, cardsPresentInEveryGame)
+        );
+    }
+
+    private Map<DomCardName, Double> calculateAveragePiles(Collection<SingleGameStats> gameByGameStats) {
+        return gameByGameStats.stream()
+            .map(SingleGameStats::getPiles)
+            .flatMap(piles -> piles.entrySet().stream())
+            .filter(card -> card.getKey().hasCardType(DomCardType.Kingdom) || card.getKey().hasCardType(DomCardType.Base))
+            .collect(Collectors.groupingBy(Map.Entry::getKey, Collectors.averagingInt(Map.Entry::getValue)));
+    }
+
+    private List<SeriesStats.AverageStatsForPlayer> calculateAverageStatsForPlayers(
+        Collection<SingleGameStats> gameByGameStats, Set<DomCardName> cardsPresentInEveryGame)
+    {
+        int numberOfPlayers = gameByGameStats.stream().findFirst().orElse(DUMMY_STATS).getPlayers().size();
+        return IntStream.range(0, numberOfPlayers)
+            .mapToObj(i -> extractStatsForSinglePlayer(i, gameByGameStats))
+            .map(player -> calculateAverageStatsForPlayer(player, cardsPresentInEveryGame))
+            .collect(Collectors.toList());
+    }
+
+    private List<SingleGameStats.Player> extractStatsForSinglePlayer(int playerIndex, Collection<SingleGameStats> gameByGameStats) {
+        return gameByGameStats.stream()
+            .map(stats -> stats.getPlayers().get(playerIndex))
+            .collect(Collectors.toList());
+    }
+
+    private SeriesStats.AverageStatsForPlayer calculateAverageStatsForPlayer(
+        List<SingleGameStats.Player> players, Set<DomCardName> cardsPresentInEveryGame)
+    {
+        Map<DomCardName, Double> averageCardsInPlayerDeck = players.stream()
+            .map(SingleGameStats.Player::getCardsInDeck)
+            .flatMap(cards -> cards.entrySet().stream())
+            .filter(card -> cardsPresentInEveryGame.contains(card.getKey()))
+            .collect(Collectors.groupingBy(Map.Entry::getKey, Collectors.averagingInt(Map.Entry::getValue)));
+
+        double averageVictoryPoints = players.stream()
+            .map(SingleGameStats.Player::getVictoryPoints)
+            .collect(Collectors.averagingInt(Integer::intValue));
+
+        return new SeriesStats.AverageStatsForPlayer(
+            players.stream().findFirst().orElse(DUMMY).getName(),
+            averageVictoryPoints, averageCardsInPlayerDeck);
+    }
+
+
+    private Map<DomCardName, Double> calculateAverageTrashPile(
+        Collection<SingleGameStats> singleGameStats, Set<DomCardName> cardsPresentInEveryGame)
+    {
+        return singleGameStats.stream()
+            .map(SingleGameStats::getTrashPile)
+            .flatMap(cards -> cards.entrySet().stream())
+            .filter(card -> cardsPresentInEveryGame.contains(card.getKey()))
+            .collect(Collectors.groupingBy(Map.Entry::getKey, Collectors.averagingInt(Map.Entry::getValue)));
+    }
+}

--- a/src/main/java/be/aga/dominionSimulator/stats/SeriesStats.java
+++ b/src/main/java/be/aga/dominionSimulator/stats/SeriesStats.java
@@ -1,0 +1,63 @@
+package be.aga.dominionSimulator.stats;
+
+import be.aga.dominionSimulator.enums.DomCardName;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class SeriesStats {
+
+    public final static SeriesStats EMPTY_SERIES_STATS = new SeriesStats(
+        Collections.emptyList(), Collections.emptyMap(), Collections.emptyMap());
+
+    private final List<AverageStatsForPlayer> averageStatsForPlayers;
+    private final Map<DomCardName, Double> averagePiles;
+    private final Map<DomCardName, Double> averageTrashPile;
+
+    public SeriesStats(List<AverageStatsForPlayer> averageStatsForPlayers,
+                       Map<DomCardName, Double> averagePiles,
+                       Map<DomCardName, Double> averageTrashPile)
+    {
+        this.averageStatsForPlayers = averageStatsForPlayers;
+        this.averagePiles = averagePiles;
+        this.averageTrashPile = averageTrashPile;
+    }
+
+    public List<AverageStatsForPlayer> getAverageStatsForPlayers() {
+        return averageStatsForPlayers;
+    }
+
+    public Map<DomCardName, Double> getAveragePiles() {
+        return averagePiles;
+    }
+
+    public Map<DomCardName, Double> getAverageTrashPile() {
+        return averageTrashPile;
+    }
+
+    public static class AverageStatsForPlayer {
+
+        private final String name;
+        private final double averageVictoryPoints;
+        private final Map<DomCardName, Double> averageCardsInTheDeck;
+
+        public AverageStatsForPlayer(String name, double averageVictoryPoints, Map<DomCardName, Double> averageCardsInTheDeck) {
+            this.name = name;
+            this.averageVictoryPoints = averageVictoryPoints;
+            this.averageCardsInTheDeck = averageCardsInTheDeck;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public double getAverageVictoryPoints() {
+            return averageVictoryPoints;
+        }
+
+        public Map<DomCardName, Double> getAverageCardsInTheDeck() {
+            return averageCardsInTheDeck;
+        }
+    }
+}

--- a/src/main/java/be/aga/dominionSimulator/stats/SingleGameStats.java
+++ b/src/main/java/be/aga/dominionSimulator/stats/SingleGameStats.java
@@ -1,0 +1,61 @@
+package be.aga.dominionSimulator.stats;
+
+import be.aga.dominionSimulator.enums.DomCardName;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class SingleGameStats {
+
+    public static final SingleGameStats DUMMY_STATS =
+        new SingleGameStats(Collections.emptyList(), Collections.emptyMap(), Collections.emptyMap());
+
+    private final List<Player> players;
+    private final Map<DomCardName, Integer> piles;
+    private final Map<DomCardName, Integer> trashPile;
+
+    public SingleGameStats(List<Player> players, Map<DomCardName, Integer> piles, Map<DomCardName, Integer> trashPile) {
+        this.players = players;
+        this.piles = piles;
+        this.trashPile = trashPile;
+    }
+
+    public List<Player> getPlayers() {
+        return players;
+    }
+
+    public Map<DomCardName, Integer> getPiles() {
+        return piles;
+    }
+
+    public Map<DomCardName, Integer> getTrashPile() {
+        return trashPile;
+    }
+
+    static class Player {
+        public static Player DUMMY = new Player("JOHN DOE", 0, Collections.emptyMap());
+
+        private final String name;
+        private final int victoryPoints;
+        private final Map<DomCardName, Integer> cardsInDeck;
+
+        public Player(String name, int victoryPoints, Map<DomCardName, Integer> cardsInDeck) {
+            this.name = name;
+            this.victoryPoints = victoryPoints;
+            this.cardsInDeck = cardsInDeck;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getVictoryPoints() {
+            return victoryPoints;
+        }
+
+        public Map<DomCardName, Integer> getCardsInDeck() {
+            return cardsInDeck;
+        }
+    }
+}

--- a/src/main/java/be/aga/dominionSimulator/stats/SingleGameStatsExtractor.java
+++ b/src/main/java/be/aga/dominionSimulator/stats/SingleGameStatsExtractor.java
@@ -1,0 +1,36 @@
+package be.aga.dominionSimulator.stats;
+
+import be.aga.dominionSimulator.DomBoard;
+import be.aga.dominionSimulator.DomCard;
+import be.aga.dominionSimulator.DomPlayer;
+import be.aga.dominionSimulator.enums.DomCardName;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class SingleGameStatsExtractor {
+
+    public SingleGameStats extractStats(DomBoard board) {
+        List<SingleGameStats.Player> players = board
+            .getPlayers().stream()
+            .map(this::extractPlayerInfo)
+            .collect(Collectors.toList());
+        Map<DomCardName, Integer>  piles = board
+            .entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, pile -> pile.getValue().size()));
+        Map<DomCardName, Integer>  trashPile = board
+            .getTrashedCards().stream()
+            .collect(Collectors.groupingBy(DomCard::getName, Collectors.reducing(0, e -> 1, Integer::sum)));
+
+        return new SingleGameStats(players, piles, trashPile);
+    }
+
+    private SingleGameStats.Player extractPlayerInfo(DomPlayer player) {
+        Map<DomCardName, Integer> cards = player
+            .getDeck().entrySet().stream()
+            .filter(pile -> !pile.getValue().isEmpty())
+            .collect(Collectors.toMap(Map.Entry::getKey, pile -> pile.getValue().size()));
+        return new SingleGameStats.Player(player.getName(), player.countVictoryPoints(), cards);
+    }
+}

--- a/src/main/java/be/aga/dominionSimulator/stats/StatsManager.java
+++ b/src/main/java/be/aga/dominionSimulator/stats/StatsManager.java
@@ -1,0 +1,30 @@
+package be.aga.dominionSimulator.stats;
+
+import be.aga.dominionSimulator.DomBoard;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class StatsManager {
+
+    private static final SingleGameStatsExtractor statsExtractor = new SingleGameStatsExtractor();
+    // Since all simulation currently only runs in a single stream it's ok to use ArrayList here.
+    private static final Collection<SingleGameStats> stats = new ArrayList<>();
+    public static boolean gatherAdditionalStats = false;
+
+    public static SeriesStats calculateCurrentSeriesStats() {
+        return gatherAdditionalStats
+            ? new AverageStatsCalculator().calculateStats(stats)
+            : SeriesStats.EMPTY_SERIES_STATS;
+    }
+
+    public static void addStatsToCurrentSeries(DomBoard board) {
+        if (gatherAdditionalStats) {
+            stats.add(statsExtractor.extractStats(board));
+        }
+    }
+
+    public static void resetCurrentSeries() {
+        stats.clear();
+    }
+}


### PR DESCRIPTION
Added additional statistics gathering - average state of kingdom piles, player decks and the trash pile.
It slightly slows the simulation (an average of one second for a 100000 run), so is made optional and is off by default. 