### PR TITLE
remove $s from README.md example commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ You will need the following to build and run the simulator:
 
 To build the simulator JAR file:
 ```
-$ mvn package
+mvn package
 ```
 
 ## Run
 
 To run the simulator:
 ```
-$ mvn exec:java
+mvn exec:java
 ```


### PR DESCRIPTION
GitHub renders the code block with a copy button, and if you put text like "$ mvn package", it will copy the $ and you can not simply paste the command to run it.  I am removing the $s so that the commands can be pasted and ran without editing.